### PR TITLE
Refine channel pruning logic to ensure expected input size matches remaining channels after pruning.

### DIFF
--- a/pruner/channel_pruning.py
+++ b/pruner/channel_pruning.py
@@ -60,8 +60,13 @@ def pruner(model, output_dir, ratio=0.5):
                 weight_copy = m.weight.data.abs().clone().cpu().numpy()
                 L1_norm = np.sum(weight_copy, axis=0)  # for input numbers, so axis is 0
                 arg_max = np.argsort(L1_norm)
-                nums_of_keep_channels = int((1 - ratio) * in_channels)
-                arg_max_rev = arg_max[::-1][:nums_of_keep_channels]
+
+                # The second conv layer always outputs feature maps of spatial size 5x5, so after pruning
+                # the flattened length must be (remaining channels) * (5 * 5).
+                expected_inputs = cfg[layer_id - 1] * 5 * 5
+                expected_inputs = min(expected_inputs, in_channels)
+
+                arg_max_rev = arg_max[::-1][:expected_inputs]
                 mask = torch.zeros(in_channels)
                 mask[arg_max_rev.tolist()] = 1
                 input_mask.append(mask)  # make input mask for this special fc


### PR DESCRIPTION
## Fix Channel-Pruning Retrain Crash

### 问题描述
- 运行 `python main.py --prune --ratio 0.6` 时，剪枝阶段完成但在随后的再训练阶段崩溃：
  ```
  RuntimeError: mat1 and mat2 shapes cannot be multiplied (256x150 and 160x48)
  ```
- 根本原因：第二个卷积层在剪枝后保留了 6 个输出通道，展平后只剩 150 个特征；但首个全连接层仍保留了 160 列权重，因此输入输出维度不匹配。

### 错误代码（节选）
```python
if layer_id == 2:
    weight_copy = m.weight.data.abs().clone().cpu().numpy()
    L1_norm = np.sum(weight_copy, axis=0)
    arg_max = np.argsort(L1_norm)
    nums_of_keep_channels = int((1 - ratio) * in_channels)
    arg_max_rev = arg_max[::-1][:nums_of_keep_channels]
    mask = torch.zeros(in_channels)
    mask[arg_max_rev.tolist()] = 1
    input_mask.append(mask)
```
上面 `nums_of_keep_channels` 用的是全连接层输入特征数（400）×`(1 - ratio)`，而不是卷积层保留下来的通道数×空间尺寸，导致特征长度和权重列数不匹配。

### 修复内容
```python
if layer_id == 2:
    weight_copy = m.weight.data.abs().clone().cpu().numpy()
    L1_norm = np.sum(weight_copy, axis=0)
    arg_max = np.argsort(L1_norm)

    expected_inputs = cfg[layer_id - 1] * 5 * 5
    expected_inputs = min(expected_inputs, in_channels)

    arg_max_rev = arg_max[::-1][:expected_inputs]
    mask = torch.zeros(in_channels)
    mask[arg_max_rev.tolist()] = 1
    input_mask.append(mask)
```
- 首个全连接层输入列数改为 `cfg[1] * 5 * 5`（即第二个卷积层保留下的通道数乘以 5×5 的空间尺寸），避免维度错位。

### 修改原因
- 原始代码在 `ratio=0.5` 时“误打误撞”未报错，是四舍五入后的整数恰好一致；`ratio=0.6` 等其它比例则必然触发维度不匹配。
- 修复后，无需额外约束即可支持任意保留通道数 ≥1 的剪枝比例，解决再训练阶段的崩溃。

### 验证
- `python main.py --prune --ratio 0.6`：剪枝、保存 `pruned_model.ckpt`、再训练均可正常完成。

```
Training on device: cuda
Epoch [1/1]: 100%|█████████████████████████████████████████████████████████████████████████████████| 235/235 [00:09<00:00, 23.62it/s, Loss=0.278]
----------
The best accuracy is: 95.87 %
save best model to model_data/best.ckpt

----------
Finished training!
pruned_model:
 LeNet(
  (feature): Sequential(
    (0): Conv2d(1, 2, kernel_size=(3, 3), stride=(1, 1))
    (1): ReLU(inplace=True)
    (2): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)
    (3): Conv2d(2, 6, kernel_size=(3, 3), stride=(1, 1))
    (4): ReLU(inplace=True)
    (5): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)
  )
  (classifier): Sequential(
    (0): Linear(in_features=150, out_features=48, bias=True)
    (1): Linear(in_features=48, out_features=33, bias=True)
    (2): Linear(in_features=33, out_features=10, bias=True)
  )
)
Conv2d    In shape: 1, Out shape 2.
Conv2d    In shape: 2, Out shape 6.
Linear    In shape: 150, Out shape 48.
Linear    In shape: 48, Out shape 33.
Linear    In shape: 33, Out shape 10.

save pruned model to: model_data\pruned_model.ckpt

Training on device: cuda
Epoch [1/2]: 100%|██████████████████████████████████████████████████████████████████████████████████| 235/235 [00:10<00:00, 21.52it/s, Loss=0.16] 
----------
The best accuracy is: 95.04 %
save best model to model_data/best_pruned.ckpt

----------
Epoch [2/2]: 100%|████████████████████████████████████████████████████████████████████████████████| 235/235 [00:10<00:00, 22.42it/s, Loss=0.0691] 
----------
The best accuracy is: 96.68 %
save best model to model_data/best_pruned.ckpt

----------
Finished retraining!
```